### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -7,6 +7,8 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/hostinger-bot/btch-downloader/security/code-scanning/1](https://github.com/hostinger-bot/btch-downloader/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block to the workflow file `.github/workflows/npm-publish.yml`. The block should be placed at the top level (before `jobs:`) to apply to all jobs, unless a job requires different permissions. For this workflow, the minimal required permissions are likely `contents: read` (for checking out code) and possibly `packages: write` if publishing to GitHub Packages. However, since the workflow publishes to npmjs.org, only `contents: read` is strictly necessary. If future changes require additional permissions, they can be added as needed. The change should be made above the `jobs:` key, after the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
