### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
 name: Node.js Package
+permissions:
+  contents: read
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/hostinger-bot/btch-downloader/security/code-scanning/2](https://github.com/hostinger-bot/btch-downloader/security/code-scanning/2)

To fix the issue, an explicit `permissions` block with the minimal required scope should be set in the workflow file. The most robust and future-proof approach is to place the `permissions:` field at the top level, which will apply to all jobs unless they override it. Since the purpose of the jobs is to build and publish to npm (which does not require write-access to the repository, but does need to be able to read the code), the minimal required scope is likely `contents: read`. If, in future, jobs need more granular write access (for instance, creating releases), that can be further specified.

To implement: add

```yaml
permissions:
  contents: read
```

immediately after the `name:` field (line 5).

No methods, imports, or additional definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
