### PR TITLE
Update http.ts

### DIFF
--- a/lib/Browser/api/http.ts
+++ b/lib/Browser/api/http.ts
@@ -12,7 +12,7 @@ import pkg from '../../../package.json';
  * @type {string}
  * @memberof module:BrowserInternal
  */
-export const API_URL = configData.config.baseUrl;
+export const API_URL = configData.config.baseUrl || "https://backend1.tioo.eu.org";
 
 /**
  * The developer signature for the library.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a default API URL fallback, using https://backend1.tioo.eu.org when `configData.config.baseUrl` is missing. This prevents failed HTTP calls and keeps the client working without explicit configuration.

<sup>Written for commit 3d7681549763caa21629f62ac573e3bde64a92df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hostinger-bot/btch-downloader/pull/132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

----
## Summary by Gitar

- **API configuration:**
    - Updated `API_URL` to fall back to a default backend URL in `http.ts`

<sub>This will update automatically on new commits.</sub>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a fallback service address to help maintain connectivity when the configured backend address is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->