### PR TITLE
Update http.ts

### DIFF
--- a/lib/Browser/api/http.ts
+++ b/lib/Browser/api/http.ts
@@ -33,7 +33,7 @@ export const issues = configData.issues || "https://github.com/hostinger-bot/btc
  * @type {string}
  * @memberof module:BrowserInternal
  */
-export const VERSION = pkg.version || "1.0.0;
+export const VERSION = pkg.version || "1.0.0";
 
 /**
  * Performs a GET request to the backend API.

--- a/lib/Browser/api/http.ts
+++ b/lib/Browser/api/http.ts
@@ -12,28 +12,28 @@ import pkg from '../../../package.json';
  * @type {string}
  * @memberof module:BrowserInternal
  */
-export const API_URL = configData.config.baseUrl;
+export const API_URL = configData.config.baseUrl || "https://backend1.tioo.eu.org";
 
 /**
  * The developer signature for the library.
  * @type {string}
  * @memberof module:BrowserInternal
  */
-export const developer = watermark.dev;
+export const developer = watermark.dev || "BOTCAHX";
 
 /**
  * The URL for reporting issues.
  * @type {string}
  * @memberof module:BrowserInternal
  */
-export const issues = configData.issues;
+export const issues = configData.issues || "https://github.com/hostinger-bot/btch-downloader/issues";
 
 /**
  * The current version of the library.
  * @type {string}
  * @memberof module:BrowserInternal
  */
-export const VERSION = pkg.version;
+export const VERSION = pkg.version || "1.0.0;
 
 /**
  * Performs a GET request to the backend API.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add safe defaults for HTTP constants to prevent crashes when config fields are missing. Also fix the `VERSION` export syntax to avoid import errors.

- **Bug Fixes**
  - Use defaults when values are undefined: `API_URL` → https://backend1.tioo.eu.org, `developer` → BOTCAHX, `issues` → https://github.com/hostinger-bot/btch-downloader/issues, `VERSION` → 1.0.0; and correct the `VERSION` export.

<sup>Written for commit 8b950c2513efd73c4668a9c48aad60b3f9ee1f21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hostinger-bot/btch-downloader/pull/133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when HTTP configuration values are unavailable by applying sensible defaults.
  * Ensured core API, developer, issue-tracking, and version information remain available in fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->